### PR TITLE
feat(1): 외부 api 호출 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,20 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-h2console'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+
+	implementation 'org.springframework.boot:spring-boot-starter-webflux:4.0.2'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	testImplementation 'com.squareup.okhttp3:mockwebserver:5.3.2'
+
+	testImplementation 'io.projectreactor:reactor-test'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/io/mipangg/holidaykeeper/common/config/WebClientConfig.java
+++ b/src/main/java/io/mipangg/holidaykeeper/common/config/WebClientConfig.java
@@ -1,0 +1,17 @@
+package io.mipangg.holidaykeeper.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .baseUrl("https://date.nager.at/api/v3")
+                .build();
+    }
+
+}

--- a/src/main/java/io/mipangg/holidaykeeper/common/dto/ExternalCountryResponse.java
+++ b/src/main/java/io/mipangg/holidaykeeper/common/dto/ExternalCountryResponse.java
@@ -1,0 +1,8 @@
+package io.mipangg.holidaykeeper.common.dto;
+
+public record ExternalCountryResponse(
+        String countryCode,
+        String name
+) {
+
+}

--- a/src/main/java/io/mipangg/holidaykeeper/common/dto/ExternalHolidayResponse.java
+++ b/src/main/java/io/mipangg/holidaykeeper/common/dto/ExternalHolidayResponse.java
@@ -1,0 +1,17 @@
+package io.mipangg.holidaykeeper.common.dto;
+
+import java.util.List;
+
+public record ExternalHolidayResponse(
+        String date,
+        String localName,
+        String name,
+        String countryCode,
+        boolean fixed,
+        boolean global,
+        List<String> counties,
+        Integer launchYear,
+        List<String> types
+) {
+
+}

--- a/src/main/java/io/mipangg/holidaykeeper/common/service/ExternalApiClient.java
+++ b/src/main/java/io/mipangg/holidaykeeper/common/service/ExternalApiClient.java
@@ -1,0 +1,36 @@
+package io.mipangg.holidaykeeper.common.service;
+
+import io.mipangg.holidaykeeper.common.dto.ExternalCountryResponse;
+import io.mipangg.holidaykeeper.common.dto.ExternalHolidayResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+public class ExternalApiClient {
+
+    private final WebClient webClient;
+
+    public ExternalApiClient(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    public List<ExternalCountryResponse> getExternalCountries() {
+        return webClient.get()
+                .uri("/AvailableCountries")
+                .retrieve()
+                .bodyToFlux(ExternalCountryResponse.class)
+                .collectList()
+                .block();
+    }
+
+    public List<ExternalHolidayResponse> getExternalHolidays(int year, String countryCode) {
+        return webClient.get()
+                .uri("/PublicHolidays/{year}/{countryCode}", year, countryCode)
+                .retrieve()
+                .bodyToFlux(ExternalHolidayResponse.class)
+                .collectList()
+                .block();
+    }
+
+}

--- a/src/test/java/io/mipangg/holidaykeeper/common/service/ExternalApiClientTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/common/service/ExternalApiClientTests.java
@@ -1,0 +1,71 @@
+package io.mipangg.holidaykeeper.common.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.mipangg.holidaykeeper.common.dto.ExternalCountryResponse;
+import java.io.IOException;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.test.StepVerifier;
+
+class ExternalApiClientTests {
+
+    private static MockWebServer mockWebServer;
+    private ExternalApiClient externalApiClient;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @BeforeEach
+    void initialize() {
+        final String baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
+        final WebClient webClient = WebClient.create(baseUrl);
+        externalApiClient = new ExternalApiClient(webClient);
+    }
+
+    @Test
+    @DisplayName("외부 api를 호출하여 국가 목록을 성공적으로 불러올 수 있다")
+    void getExternalCountries_success_test() {
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("""
+                         [
+                                {
+                                    "countryCode": "BR",
+                                    "name": "Brazil"
+                                },
+                                {
+                                    "countryCode": "KR",
+                                    "name": "South Korea"
+                                }
+                         ]
+                """)
+                .addHeader("Content-Type", "application/json"));
+
+        final List<ExternalCountryResponse> countries = externalApiClient.getExternalCountries();
+
+        assertThat(countries.getFirst().countryCode()).isEqualTo("BR");
+        assertThat(countries.getFirst().name()).isEqualTo("Brazil");
+        assertThat(countries.getLast().countryCode()).isEqualTo("KR");
+        assertThat(countries.getLast().name()).isEqualTo("South Korea");
+
+    }
+
+}

--- a/src/test/java/io/mipangg/holidaykeeper/common/service/ExternalApiClientTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/common/service/ExternalApiClientTests.java
@@ -1,7 +1,6 @@
 package io.mipangg.holidaykeeper.common.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.mipangg.holidaykeeper.common.dto.ExternalCountryResponse;
 import java.io.IOException;
@@ -9,13 +8,11 @@ import java.util.List;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.test.StepVerifier;
 
 class ExternalApiClientTests {
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #1

## 📝작업 내용
- 2개의 외부 api를 호출하여 국가 정보 목록과 공휴일 목록을 불러오는 기능 구현

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함
