### PR TITLE
feat(7): 특정 연도·국가의 공휴일 레코드 전체 삭제 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/controller/HolidayController.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/controller/HolidayController.java
@@ -3,9 +3,14 @@ package io.mipangg.holidaykeeper.domain.holiday.controller;
 import io.mipangg.holidaykeeper.domain.country.entity.Country;
 import io.mipangg.holidaykeeper.domain.country.service.CountryService;
 import io.mipangg.holidaykeeper.domain.holiday.service.HolidayService;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -21,9 +26,18 @@ public class HolidayController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public void createHoliday() {
+    public void createHolidays() {
         Map<String, Country> countries = countryService.saveCountries();
         holidayService.saveHolidays(countries);
+    }
+
+    @DeleteMapping("/{year}/{countryCode}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteHolidays(
+            @PathVariable @Positive @NotNull Integer year,
+            @PathVariable @NotBlank String countryCode
+    ) {
+        holidayService.deleteHolidays(year, countryCode);
     }
 
 

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/entity/Holiday.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/entity/Holiday.java
@@ -18,6 +18,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(
@@ -33,6 +35,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE holiday SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 public class Holiday extends BaseEntity {
 
     @Id
@@ -60,5 +64,8 @@ public class Holiday extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "country_id", nullable = false)
     private Country country;
+
+    @Column(nullable = false)
+    private boolean deleted;
 
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayRepository.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayRepository.java
@@ -1,9 +1,19 @@
 package io.mipangg.holidaykeeper.domain.holiday.repository;
 
 import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface HolidayRepository extends JpaRepository<Holiday, Long> {
 
     boolean existsBy();
+
+    @Query("select h from Holiday h "
+            + "where function('year', h.date) = :year and h.country.countryCode = :countryCode")
+    List<Holiday> findByYearAndCountryCode(
+            @Param("year") Integer year,
+            @Param("countryCode") String countryCode
+    );
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
@@ -79,7 +79,14 @@ public class HolidayService {
 
     @Transactional
     public void deleteHolidays(Integer year, String countryCode) {
-
+        List<Holiday> targetHolidays = holidayRepository.findByYearAndCountryCode(year, countryCode);
+        if (targetHolidays.isEmpty()) {
+            throw new CustomLogicException(
+                    ErrorCode.NOT_FOUND,
+                    "해당하는 연도, 국가코드의 공휴일 목록을 찾을 수 없습니다."
+            );
+        }
+        holidayRepository.deleteAll(targetHolidays);
     }
 
     private static String createUniqueKey(ExternalHolidayResponse ext) {

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
@@ -88,7 +88,7 @@ public class HolidayService {
         }
 
         holidayTypeService.deleteHolidayTypes(targetHolidays);
-//        holidayCountyService.deleteHolidayCounties(targetHolidays);
+        holidayCountyService.deleteHolidayCounties(targetHolidays);
 
         holidayRepository.deleteAll(targetHolidays);
     }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
@@ -77,6 +77,11 @@ public class HolidayService {
 
     }
 
+    @Transactional
+    public void deleteHolidays(Integer year, String countryCode) {
+
+    }
+
     private static String createUniqueKey(ExternalHolidayResponse ext) {
         return ext.date() + "|" + ext.localName() + "|" + ext.countryCode();
     }
@@ -103,5 +108,4 @@ public class HolidayService {
         }
         return result;
     }
-
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
@@ -86,6 +86,10 @@ public class HolidayService {
                     "해당하는 연도, 국가코드의 공휴일 목록을 찾을 수 없습니다."
             );
         }
+
+        holidayTypeService.deleteHolidayTypes(targetHolidays);
+//        holidayCountyService.deleteHolidayCounties(targetHolidays);
+
         holidayRepository.deleteAll(targetHolidays);
     }
 

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holidayCounty/repository/HolidayCountyRepository.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holidayCounty/repository/HolidayCountyRepository.java
@@ -1,8 +1,14 @@
 package io.mipangg.holidaykeeper.domain.holidayCounty.repository;
 
+import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
 import io.mipangg.holidaykeeper.domain.holidayCounty.entity.HolidayCounty;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface HolidayCountyRepository extends JpaRepository<HolidayCounty, Long> {
 
+    @Query("select hc from HolidayCounty hc where hc.holiday in :holidays")
+    List<HolidayCounty> findByHolidayIn(@Param("holidays") List<Holiday> holidays);
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holidayCounty/service/HolidayCountyService.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holidayCounty/service/HolidayCountyService.java
@@ -48,4 +48,13 @@ public class HolidayCountyService {
         holidayCountyRepository.saveAll(holidayCounties);
     }
 
+    @Transactional
+    public void deleteHolidayCounties(List<Holiday> holidays) {
+        List<HolidayCounty> targetHolidayCounties =
+                holidayCountyRepository.findByHolidayIn(holidays);
+
+        if (targetHolidayCounties != null && !targetHolidayCounties.isEmpty()) {
+            holidayCountyRepository.deleteAll(targetHolidayCounties);
+        }
+    }
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holidayType/repository/HolidayTypeRepository.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holidayType/repository/HolidayTypeRepository.java
@@ -1,8 +1,14 @@
 package io.mipangg.holidaykeeper.domain.holidayType.repository;
 
+import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
 import io.mipangg.holidaykeeper.domain.holidayType.entity.HolidayType;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface HolidayTypeRepository extends JpaRepository<HolidayType, Long> {
 
+    @Query("select ht from HolidayType ht where ht.holiday in :holidays")
+    List<HolidayType> findByHolidayIn(@Param("holidays") List<Holiday> holidays);
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holidayType/service/HolidayTypeService.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holidayType/service/HolidayTypeService.java
@@ -44,4 +44,13 @@ public class HolidayTypeService {
 
         holidayTypeRepository.saveAll(holidayTypes);
     }
+
+    @Transactional
+    public void deleteHolidayTypes(List<Holiday> holidays) {
+        List<HolidayType> targetHolidayTypes = holidayTypeRepository.findByHolidayIn(holidays);
+
+        if (!targetHolidayTypes.isEmpty()) {
+            holidayTypeRepository.deleteAll(targetHolidayTypes);
+        }
+    }
 }

--- a/src/main/java/io/mipangg/holidaykeeper/global/exception/ErrorCode.java
+++ b/src/main/java/io/mipangg/holidaykeeper/global/exception/ErrorCode.java
@@ -13,7 +13,7 @@ public enum ErrorCode {
     /*
      * 404 NOT_FOUND: 리소스를 찾을 수 없음
      */
-    NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "테이터를 찾을 수 없습니다."),
 
     /*
      * 409 CONFLICT

--- a/src/test/java/io/mipangg/holidaykeeper/domain/holiday/controller/HolidayControllerTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/holiday/controller/HolidayControllerTests.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/src/test/java/io/mipangg/holidaykeeper/domain/holiday/controller/HolidayControllerTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/holiday/controller/HolidayControllerTests.java
@@ -2,6 +2,7 @@ package io.mipangg.holidaykeeper.domain.holiday.controller;
 
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -30,15 +31,28 @@ class HolidayControllerTests {
 
     @Test
     @DisplayName("공휴일 데이터 적재 테스트")
-    void createHolidayTest() throws Exception {
+    void createHolidaysTest() throws Exception {
 
-        mockMvc.perform(post("/holidays")
-                        .contentType(MediaType.APPLICATION_JSON))
+        mockMvc.perform(post("/holidays"))
                 .andExpect(status().isCreated())
                 .andDo(print());
 
         verify(countryService).saveCountries();
         verify(holidayService).saveHolidays(anyMap());
+    }
+
+    @Test
+    @DisplayName("공휴일 데이터 삭제 테스트")
+    void deleteHolidaysTest() throws Exception {
+
+        int year = 2026;
+        String countryCode = "KR";
+
+        mockMvc.perform(delete("/holidays/{year}/{countryCode}", year, countryCode))
+                .andExpect(status().isNoContent())
+                .andDo(print());
+
+        verify(holidayService).deleteHolidays(year, countryCode);
     }
 
 }

--- a/src/test/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayServiceTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayServiceTests.java
@@ -1,10 +1,9 @@
 package io.mipangg.holidaykeeper.domain.holiday.service;
 
 import static io.mipangg.holidaykeeper.util.TestUtil.getCountries;
+import static io.mipangg.holidaykeeper.util.TestUtil.getHolidayKorea;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -12,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.mipangg.holidaykeeper.domain.country.entity.Country;
+import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
 import io.mipangg.holidaykeeper.domain.holiday.properties.HolidayProperties;
 import io.mipangg.holidaykeeper.domain.holiday.repository.HolidayRepository;
 import io.mipangg.holidaykeeper.domain.holidayCounty.service.HolidayCountyService;
@@ -40,12 +40,6 @@ class HolidayServiceTests {
 
     @Mock
     private ExternalApiClient externalApiClient;
-
-    @Mock
-    private HolidayCountyService holidayCountyService;
-
-    @Mock
-    private HolidayTypeService holidayTypeService;
 
     @Mock
     private HolidayProperties holidayProperties;
@@ -105,6 +99,42 @@ class HolidayServiceTests {
                 }
         ).isInstanceOf(CustomLogicException.class)
                 .hasMessage("이미 존재하는 데이터입니다.");
+
+    }
+
+    @Test
+    @DisplayName("holiday 삭제 테스트")
+    void deleteHolidaysTest() {
+
+        int year = 2026;
+        String countryCode = "KR";
+
+        List<Holiday> targetHolidays = List.of(
+                getHolidayKorea()
+        );
+
+        when(holidayRepository.findByYearAndCountryCode(year, countryCode))
+                .thenReturn(targetHolidays);
+
+        holidayService.deleteHolidays(year, countryCode);
+
+        verify(holidayRepository).findByYearAndCountryCode(year, countryCode);
+        verify(holidayRepository).deleteAll(targetHolidays);
+
+    }
+
+    @Test
+    @DisplayName("삭제하려는 연도, 국가코드에 해당하는 공휴일 목록이 없을 때 404 발생 테스트")
+    void deleteHolidays404FailTest() {
+
+        when(holidayRepository.findByYearAndCountryCode(anyInt(), anyString()))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(
+                () -> {
+                    holidayService.deleteHolidays(anyInt(), anyString());
+                }
+        ).isInstanceOf(CustomLogicException.class);
 
     }
 

--- a/src/test/java/io/mipangg/holidaykeeper/domain/holidayCounty/service/HolidayCountyServiceTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/holidayCounty/service/HolidayCountyServiceTests.java
@@ -10,6 +10,7 @@ import io.mipangg.holidaykeeper.domain.county.entity.County;
 import io.mipangg.holidaykeeper.domain.county.service.CountyService;
 import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayCountiesDto;
 import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
+import io.mipangg.holidaykeeper.domain.holidayCounty.entity.HolidayCounty;
 import io.mipangg.holidaykeeper.domain.holidayCounty.repository.HolidayCountyRepository;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +57,39 @@ class HolidayCountyServiceTests {
         holidayCountyService.saveHolidayCounties(holidayCountiesDtos);
 
         verify(holidayCountyRepository).saveAll(anySet());
+    }
+
+    @Test
+    @DisplayName("holidayCounty 삭제 테스트")
+    void deleteHolidayCountiesTest() {
+        List<Holiday> holidays = List.of(getHolidayCanada());
+        Country canada = holidays.getFirst().getCountry();
+        List<HolidayCounty> targetHolidayCounties = List.of(
+                HolidayCounty.builder()
+                        .county(
+                                County.builder()
+                                        .county("CA-AB")
+                                        .country(canada)
+                                        .build()
+                        )
+                        .build(),
+                HolidayCounty.builder()
+                        .county(
+                                County.builder()
+                                        .county("CA-PE")
+                                        .country(canada)
+                                        .build()
+                        )
+                        .build()
+        );
+
+        when(holidayCountyRepository.findByHolidayIn(holidays)).thenReturn(targetHolidayCounties);
+
+        holidayCountyService.deleteHolidayCounties(holidays);
+
+        verify(holidayCountyRepository).findByHolidayIn(holidays);
+        verify(holidayCountyRepository).deleteAll(targetHolidayCounties);
+
     }
 
 }

--- a/src/test/java/io/mipangg/holidaykeeper/domain/holidayType/service/HolidayTypeServiceTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/holidayType/service/HolidayTypeServiceTests.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayTypesDto;
+import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
+import io.mipangg.holidaykeeper.domain.holidayType.entity.HolidayType;
 import io.mipangg.holidaykeeper.domain.holidayType.repository.HolidayTypeRepository;
 import io.mipangg.holidaykeeper.domain.type.entity.Type;
 import io.mipangg.holidaykeeper.domain.type.service.TypeService;
@@ -52,6 +54,31 @@ class HolidayTypeServiceTests {
         holidayTypeService.saveHolidayTypes(holidayTypesDtos);
 
         verify(holidayTypeRepository).saveAll(anyList());
+
+    }
+
+    @Test
+    @DisplayName("holidayType 삭제 테스트")
+    void deleteHolidayTypesTest() {
+
+        List<Holiday> holidays = List.of(getHolidayBrazil());
+        List<HolidayType> targetHolidayTypes = List.of(
+                HolidayType.builder()
+                        .type(Type.builder().type("Public").build())
+                        .holiday(holidays.getFirst())
+                        .build(),
+                HolidayType.builder()
+                        .type(Type.builder().type("Bank").build())
+                        .holiday(holidays.getFirst())
+                        .build()
+        );
+
+        when(holidayTypeRepository.findByHolidayIn(holidays)).thenReturn(targetHolidayTypes);
+
+        holidayTypeService.deleteHolidayTypes(holidays);
+
+        verify(holidayTypeRepository).findByHolidayIn(anyList());
+        verify(holidayTypeRepository).deleteAll(targetHolidayTypes);
 
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #7 

## 📝작업 내용
- 특정 연도·국가의 공휴일 레코드 전체 삭제 
- holiday는 soft delete
- 삭제된 holiday가 포함된 holidayType과 holidayCounty는 삭제

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함
