### PR TITLE
feat(9): 필터링, 페이징과 함께 특정 연도, 국가의 공휴일 목록 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ configurations {
 repositories {
 	mavenCentral()
 }
-
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -31,11 +30,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -45,6 +51,7 @@ dependencies {
 	testImplementation 'io.projectreactor:reactor-test'
 
 }
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/io/mipangg/holidaykeeper/domain/common/PageResponse.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/common/PageResponse.java
@@ -1,0 +1,29 @@
+package io.mipangg.holidaykeeper.domain.common;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PageResponse<T> {
+    private List<T> content;        // 현재 페이지 데이터 목록
+    private int page;        // 현재 페이지 번호 (0부터 시작)
+    private int size;           // 페이지 크기
+    private int totalPages;         // 전체 페이지 수
+    private long totalElements;     // 전체 데이터 수
+    private boolean hasNext;        // 다음 페이지 존재 여부
+
+    // Page<T> 객체를 PageResponse로 변환하는 생성자
+    public PageResponse(Page<T> page) {
+        this.content = page.getContent();
+        this.page = page.getNumber();
+        this.size = page.getSize();
+        this.totalPages = page.getTotalPages();
+        this.totalElements = page.getTotalElements();
+        this.hasNext = page.hasNext();
+    }
+
+}

--- a/src/main/java/io/mipangg/holidaykeeper/domain/common/PageResponse.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/common/PageResponse.java
@@ -10,8 +10,8 @@ import org.springframework.data.domain.Page;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PageResponse<T> {
     private List<T> content;        // 현재 페이지 데이터 목록
-    private int page;        // 현재 페이지 번호 (0부터 시작)
-    private int size;           // 페이지 크기
+    private int page;        // 조회할 페이지 번호 (0부터 시작)
+    private int size;           // 한 페이지당 조회할 데이터 개수
     private int totalPages;         // 전체 페이지 수
     private long totalElements;     // 전체 데이터 수
     private boolean hasNext;        // 다음 페이지 존재 여부

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/controller/HolidayController.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/controller/HolidayController.java
@@ -1,15 +1,23 @@
 package io.mipangg.holidaykeeper.domain.holiday.controller;
 
+import io.mipangg.holidaykeeper.domain.common.PageResponse;
 import io.mipangg.holidaykeeper.domain.country.entity.Country;
 import io.mipangg.holidaykeeper.domain.country.service.CountryService;
+import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayListReadResponse;
+import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayReadRequest;
 import io.mipangg.holidaykeeper.domain.holiday.service.HolidayService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +32,11 @@ public class HolidayController {
     private final HolidayService holidayService;
     private final CountryService countryService;
 
+    @Operation(summary = "데이터 적재")
+    @ApiResponse(responseCode = "201", description = "국가, 공휴일 데이터 저장 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    @ApiResponse(responseCode = "409", description = "이미 존재하는 데이터")
+    @ApiResponse(responseCode = "500", description = "외부 API 호출 실패")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public void createHolidays() {
@@ -31,6 +44,10 @@ public class HolidayController {
         holidayService.saveHolidays(countries);
     }
 
+    @Operation(summary = "특정 연도·국가의 공휴일 레코드 전체 삭제")
+    @ApiResponse(responseCode = "204", description = "특정 연도·국가의 공휴일 레코드 전체 삭제 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    @ApiResponse(responseCode = "404", description = "특정 연도·국가의 공휴일을 찾을 수 없음")
     @DeleteMapping("/{year}/{countryCode}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteHolidays(
@@ -38,6 +55,20 @@ public class HolidayController {
             @PathVariable @NotBlank String countryCode
     ) {
         holidayService.deleteHolidays(year, countryCode);
+    }
+
+    @Operation(summary = "특정 연도·국가의 공휴일 목록 조회")
+    @ApiResponse(responseCode = "200", description = "특정 연도·국가의 공휴일 목록 조회 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    @ApiResponse(responseCode = "404", description = "특정 연도·국가의 공휴일을 찾을 수 없음")
+    @GetMapping("/{year}/{countryCode}")
+    @ResponseStatus(HttpStatus.OK)
+    public PageResponse<HolidayListReadResponse> readHolidays(
+            @PathVariable @Positive @NotNull Integer year,
+            @PathVariable @NotBlank String countryCode,
+            @Valid @ParameterObject HolidayReadRequest request
+    ) {
+        return holidayService.searchHolidays(year, countryCode, request);
     }
 
 

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/dto/HolidayListReadResponse.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/dto/HolidayListReadResponse.java
@@ -1,0 +1,15 @@
+package io.mipangg.holidaykeeper.domain.holiday.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record HolidayListReadResponse(
+        Long id,
+        LocalDate date,
+        String localName,
+        String name,
+        String country,
+        List<String> counties,
+        List<String> types
+) {
+}

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/dto/HolidayReadRequest.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/dto/HolidayReadRequest.java
@@ -5,6 +5,8 @@ import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
 
 public record HolidayReadRequest(
         @Schema(description = "조회할 페이지 번호 (기본값: 0, 0부터 시작)")
@@ -22,14 +24,14 @@ public record HolidayReadRequest(
         String type,
 
         @Schema(description = "조회 시작 날짜", example = "2025-01-01")
-        @Positive
         @Nullable
-        Integer from,
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        LocalDate from,
 
         @Schema(description = "조회 종료 날짜", example = "2025-03-31")
-        @Positive
         @Nullable
-        Integer to
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        LocalDate to
 ) {
     public HolidayReadRequest {
         if (page == null) {

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/dto/HolidayReadRequest.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/dto/HolidayReadRequest.java
@@ -1,0 +1,43 @@
+package io.mipangg.holidaykeeper.domain.holiday.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+
+public record HolidayReadRequest(
+        @Schema(description = "조회할 페이지 번호 (기본값: 0, 0부터 시작)")
+        @Min(0)
+        @Max(100)
+        Integer page,
+
+        @Schema(description = "한 페이지당 조회할 데이터 개수 (기본값: 20)")
+        @Min(0)
+        @Max(100)
+        Integer size,
+
+        @Schema(description = "공휴일 타입 필터", example = "Public")
+        @Nullable
+        String type,
+
+        @Schema(description = "조회 시작 날짜", example = "2025-01-01")
+        @Positive
+        @Nullable
+        Integer from,
+
+        @Schema(description = "조회 종료 날짜", example = "2025-03-31")
+        @Positive
+        @Nullable
+        Integer to
+) {
+    public HolidayReadRequest {
+        if (page == null) {
+            page = 0;
+        }
+
+        if (size == null) {
+            size = 20;
+        }
+    }
+}

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayCustomRepository.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayCustomRepository.java
@@ -2,6 +2,7 @@ package io.mipangg.holidaykeeper.domain.holiday.repository;
 
 
 import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
+import java.time.LocalDate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,8 +12,8 @@ public interface HolidayCustomRepository {
             Integer year,
             String countryCode,
             String type,
-            Integer from,
-            Integer to,
+            LocalDate from,
+            LocalDate to,
             Pageable pageable
     );
 

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayCustomRepository.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayCustomRepository.java
@@ -1,0 +1,4 @@
+package io.mipangg.holidaykeeper.domain.holiday.repository;
+
+public interface HolidayCustomRepository {
+}

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayCustomRepository.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayCustomRepository.java
@@ -1,4 +1,19 @@
 package io.mipangg.holidaykeeper.domain.holiday.repository;
 
+
+import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface HolidayCustomRepository {
+
+    Page<Holiday> searchHoliday(
+            Integer year,
+            String countryCode,
+            String type,
+            Integer from,
+            Integer to,
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayRepository.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface HolidayRepository extends JpaRepository<Holiday, Long> {
+public interface HolidayRepository extends JpaRepository<Holiday, Long>, HolidayCustomRepository {
 
     boolean existsBy();
 
@@ -16,4 +16,5 @@ public interface HolidayRepository extends JpaRepository<Holiday, Long> {
             @Param("year") Integer year,
             @Param("countryCode") String countryCode
     );
+
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayRepositoryImpl.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayRepositoryImpl.java
@@ -1,4 +1,115 @@
 package io.mipangg.holidaykeeper.domain.holiday.repository;
 
-public class HolidayRepositoryImpl {
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.mipangg.holidaykeeper.domain.country.entity.QCountry;
+import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
+import io.mipangg.holidaykeeper.domain.holiday.entity.QHoliday;
+import io.mipangg.holidaykeeper.domain.holidayType.entity.QHolidayType;
+import io.mipangg.holidaykeeper.domain.type.entity.QType;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class HolidayRepositoryImpl implements HolidayCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Holiday> searchHoliday(
+            Integer year,
+            String countryCode,
+            String typeName,
+            Integer from,
+            Integer to,
+            Pageable pageable
+    ) {
+
+        QHoliday holiday = QHoliday.holiday;
+        QHolidayType holidayType = QHolidayType.holidayType;
+        QType type = QType.type1;
+        QCountry country = QCountry.country;
+
+        LocalDate startOfYear = LocalDate.of(year, 1, 1);
+        LocalDate endOfYear = LocalDate.of(year, 12, 31);
+
+        // ID 페이징
+        List<Tuple> tuples = queryFactory
+                .select(holiday.id, holiday.date) // date 기준 오름차순 정렬을 위해 date도 추가
+                .from(holiday)
+                .join(holiday.country, country)
+                .leftJoin(holidayType).on(holidayType.holiday.eq(holiday))
+                .leftJoin(type).on(holidayType.type.eq(type))
+                .where(
+                        holiday.date.between(startOfYear, endOfYear),
+                        country.countryCode.eq(countryCode),
+                        typeEq(typeName),
+                        fromGoe(year, from),
+                        toLoe(year, to)
+                )
+                .orderBy(holiday.date.asc())
+                .distinct()
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        List<Long> ids = new ArrayList<>();
+        for (Tuple tuple : tuples) {
+            ids.add(tuple.get(holiday.id));
+        }
+
+        if (ids.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        // fetch join
+        List<Holiday> content = queryFactory
+                .selectFrom(holiday)
+                .join(holiday.country, country).fetchJoin() // country만 fetch
+                .where(holiday.id.in(ids))
+                .orderBy(holiday.date.asc())
+                .fetch();
+
+        // count
+        Long total = queryFactory
+                .select(holiday.countDistinct())
+                .from(holiday)
+                .join(holiday.country, country)
+                .leftJoin(holidayType).on(holidayType.holiday.eq(holiday))
+                .leftJoin(type).on(holidayType.type.eq(type))
+                .where(
+                        holiday.date.between(startOfYear, endOfYear),
+                        country.countryCode.eq(countryCode),
+                        typeEq(typeName),
+                        fromGoe(year, from),
+                        toLoe(year, to)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private BooleanExpression typeEq(String typeName) {
+        return typeName == null ? null : QType.type1.type.eq(typeName);
+    }
+
+    private BooleanExpression fromGoe(Integer year, Integer from) {
+        if (from == null) return null;
+        return QHoliday.holiday.date.goe(LocalDate.of(year, 1, 1).withDayOfYear(from));
+    }
+
+    private BooleanExpression toLoe(Integer year, Integer to) {
+        if (to == null) return null;
+        return QHoliday.holiday.date.loe(LocalDate.of(year, 1, 1).withDayOfYear(to));
+    }
+
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayRepositoryImpl.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayRepositoryImpl.java
@@ -1,0 +1,4 @@
+package io.mipangg.holidaykeeper.domain.holiday.repository;
+
+public class HolidayRepositoryImpl {
+}

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayRepositoryImpl.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/repository/HolidayRepositoryImpl.java
@@ -29,8 +29,8 @@ public class HolidayRepositoryImpl implements HolidayCustomRepository {
             Integer year,
             String countryCode,
             String typeName,
-            Integer from,
-            Integer to,
+            LocalDate from,
+            LocalDate to,
             Pageable pageable
     ) {
 
@@ -53,8 +53,8 @@ public class HolidayRepositoryImpl implements HolidayCustomRepository {
                         holiday.date.between(startOfYear, endOfYear),
                         country.countryCode.eq(countryCode),
                         typeEq(typeName),
-                        fromGoe(year, from),
-                        toLoe(year, to)
+                        fromGoe(from),
+                        toLoe(to)
                 )
                 .orderBy(holiday.date.asc())
                 .distinct()
@@ -90,8 +90,8 @@ public class HolidayRepositoryImpl implements HolidayCustomRepository {
                         holiday.date.between(startOfYear, endOfYear),
                         country.countryCode.eq(countryCode),
                         typeEq(typeName),
-                        fromGoe(year, from),
-                        toLoe(year, to)
+                        fromGoe(from),
+                        toLoe(to)
                 )
                 .fetchOne();
 
@@ -102,14 +102,12 @@ public class HolidayRepositoryImpl implements HolidayCustomRepository {
         return typeName == null ? null : QType.type1.type.eq(typeName);
     }
 
-    private BooleanExpression fromGoe(Integer year, Integer from) {
-        if (from == null) return null;
-        return QHoliday.holiday.date.goe(LocalDate.of(year, 1, 1).withDayOfYear(from));
+    private BooleanExpression fromGoe(LocalDate from) {
+        return from == null ? null : QHoliday.holiday.date.goe(from);
     }
 
-    private BooleanExpression toLoe(Integer year, Integer to) {
-        if (to == null) return null;
-        return QHoliday.holiday.date.loe(LocalDate.of(year, 1, 1).withDayOfYear(to));
+    private BooleanExpression toLoe(LocalDate to) {
+        return to == null ? null : QHoliday.holiday.date.loe(to);
     }
 
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
@@ -2,6 +2,7 @@ package io.mipangg.holidaykeeper.domain.holiday.service;
 
 import io.mipangg.holidaykeeper.domain.common.PageResponse;
 import io.mipangg.holidaykeeper.domain.country.entity.Country;
+import io.mipangg.holidaykeeper.domain.county.entity.County;
 import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayCountiesDto;
 import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayListReadResponse;
 import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayReadRequest;
@@ -11,21 +12,23 @@ import io.mipangg.holidaykeeper.domain.holiday.properties.HolidayProperties;
 import io.mipangg.holidaykeeper.domain.holiday.repository.HolidayRepository;
 import io.mipangg.holidaykeeper.domain.holidayCounty.service.HolidayCountyService;
 import io.mipangg.holidaykeeper.domain.holidayType.service.HolidayTypeService;
+import io.mipangg.holidaykeeper.domain.type.entity.Type;
 import io.mipangg.holidaykeeper.external.dto.ExternalHolidayResponse;
 import io.mipangg.holidaykeeper.external.service.ExternalApiClient;
 import io.mipangg.holidaykeeper.global.exception.CustomLogicException;
 import io.mipangg.holidaykeeper.global.exception.ErrorCode;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -94,8 +97,10 @@ public class HolidayService {
             );
         }
 
-        holidayTypeService.deleteHolidayTypes(targetHolidays);
-        holidayCountyService.deleteHolidayCounties(targetHolidays);
+        List<Long> holidayIds = getHolidayIds(targetHolidays);
+
+        holidayTypeService.deleteHolidayTypes(holidayIds);
+        holidayCountyService.deleteHolidayCounties(holidayIds);
 
         holidayRepository.deleteAll(targetHolidays);
     }
@@ -106,10 +111,50 @@ public class HolidayService {
             String countryCode,
             HolidayReadRequest request
     ) {
-        return null;
+
+        Pageable pageable = PageRequest.of(
+                request.page(),
+                request.size(),
+                Sort.by("date").ascending()
+        );
+
+        Page<Holiday> page = holidayRepository.searchHoliday(
+                year,
+                countryCode,
+                request.type(),
+                request.from(),
+                request.to(),
+                pageable
+        );
+
+        List<Long> holidayIds = getHolidayIds(page.getContent());
+        Map<Long, List<String>> holidayCountyMap =
+                holidayCountyService.getHolidayCountyMapByHolidayIds(holidayIds);
+        Map<Long, List<String>> holidayTypeMap =
+                holidayTypeService.getHolidayTypeMapByHolidayIds(holidayIds);
+
+        Page<HolidayListReadResponse> respPage = page.map(holiday ->
+                new HolidayListReadResponse(
+                        holiday.getId(),
+                        holiday.getDate(),
+                        holiday.getLocalName(),
+                        holiday.getName(),
+                        holiday.getCountry().getCountryCode(),
+                        holidayCountyMap.getOrDefault(holiday.getId(), List.of()),
+                        holidayTypeMap.getOrDefault(holiday.getId(), List.of())
+                )
+        );
+
+        return new PageResponse<>(respPage);
     }
 
-    private static String createUniqueKey(ExternalHolidayResponse ext) {
+    private List<Long> getHolidayIds(List<Holiday> holidays) {
+        return holidays.stream()
+                .map(Holiday::getId)
+                .toList();
+    }
+
+    private String createUniqueKey(ExternalHolidayResponse ext) {
         return ext.date() + "|" + ext.localName() + "|" + ext.countryCode();
     }
 

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
@@ -2,7 +2,6 @@ package io.mipangg.holidaykeeper.domain.holiday.service;
 
 import io.mipangg.holidaykeeper.domain.common.PageResponse;
 import io.mipangg.holidaykeeper.domain.country.entity.Country;
-import io.mipangg.holidaykeeper.domain.county.entity.County;
 import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayCountiesDto;
 import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayListReadResponse;
 import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayReadRequest;
@@ -12,7 +11,6 @@ import io.mipangg.holidaykeeper.domain.holiday.properties.HolidayProperties;
 import io.mipangg.holidaykeeper.domain.holiday.repository.HolidayRepository;
 import io.mipangg.holidaykeeper.domain.holidayCounty.service.HolidayCountyService;
 import io.mipangg.holidaykeeper.domain.holidayType.service.HolidayTypeService;
-import io.mipangg.holidaykeeper.domain.type.entity.Type;
 import io.mipangg.holidaykeeper.external.dto.ExternalHolidayResponse;
 import io.mipangg.holidaykeeper.external.service.ExternalApiClient;
 import io.mipangg.holidaykeeper.global.exception.CustomLogicException;
@@ -23,7 +21,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -112,6 +109,8 @@ public class HolidayService {
             HolidayReadRequest request
     ) {
 
+        validateDateYear(year, request);
+
         Pageable pageable = PageRequest.of(
                 request.page(),
                 request.size(),
@@ -179,5 +178,15 @@ public class HolidayService {
             result.add(thisYear - i);
         }
         return result;
+    }
+
+    private static void validateDateYear(Integer year, HolidayReadRequest request) {
+        if (request.from() != null && request.from().getYear() != year) {
+            throw new CustomLogicException(ErrorCode.BAD_REQUEST, "잘못된 조회 시작 날짜 입니다.");
+        }
+
+        if (request.to() != null && request.to().getYear() != year) {
+            throw new CustomLogicException(ErrorCode.BAD_REQUEST, "잘못된 조회 종료 날짜 입니다.");
+        }
     }
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayService.java
@@ -1,7 +1,10 @@
 package io.mipangg.holidaykeeper.domain.holiday.service;
 
+import io.mipangg.holidaykeeper.domain.common.PageResponse;
 import io.mipangg.holidaykeeper.domain.country.entity.Country;
 import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayCountiesDto;
+import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayListReadResponse;
+import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayReadRequest;
 import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayTypesDto;
 import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
 import io.mipangg.holidaykeeper.domain.holiday.properties.HolidayProperties;
@@ -12,6 +15,10 @@ import io.mipangg.holidaykeeper.external.dto.ExternalHolidayResponse;
 import io.mipangg.holidaykeeper.external.service.ExternalApiClient;
 import io.mipangg.holidaykeeper.global.exception.CustomLogicException;
 import io.mipangg.holidaykeeper.global.exception.ErrorCode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -64,7 +71,7 @@ public class HolidayService {
                 if (ext.types() != null && !ext.types().isEmpty()) {
                     holidayTypesDtos.add(new HolidayTypesDto(holiday, ext.types()));
                 }
-                if (ext.counties() != null && !ext.counties().isEmpty()) {
+                if (!ext.global() && ext.counties() != null) {
                     holidayCountiesDtos.add(new HolidayCountiesDto(holiday, ext.counties()));
                 }
             }
@@ -91,6 +98,15 @@ public class HolidayService {
         holidayCountyService.deleteHolidayCounties(targetHolidays);
 
         holidayRepository.deleteAll(targetHolidays);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<HolidayListReadResponse> searchHolidays(
+            Integer year,
+            String countryCode,
+            HolidayReadRequest request
+    ) {
+        return null;
     }
 
     private static String createUniqueKey(ExternalHolidayResponse ext) {

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holidayCounty/repository/HolidayCountyRepository.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holidayCounty/repository/HolidayCountyRepository.java
@@ -1,6 +1,5 @@
 package io.mipangg.holidaykeeper.domain.holidayCounty.repository;
 
-import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
 import io.mipangg.holidaykeeper.domain.holidayCounty.entity.HolidayCounty;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +8,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface HolidayCountyRepository extends JpaRepository<HolidayCounty, Long> {
 
-    @Query("select hc from HolidayCounty hc where hc.holiday in :holidays")
-    List<HolidayCounty> findByHolidayIn(@Param("holidays") List<Holiday> holidays);
+    @Query("select hc from HolidayCounty hc "
+            + "join fetch hc.county where hc.holiday.id in :holidayIds")
+    List<HolidayCounty> findByHolidayIdIn(@Param("holidayIds") List<Long> holidayIds);
+
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holidayCounty/service/HolidayCountyService.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holidayCounty/service/HolidayCountyService.java
@@ -8,6 +8,7 @@ import io.mipangg.holidaykeeper.domain.holidayCounty.dto.CountyElemDto;
 import io.mipangg.holidaykeeper.domain.holidayCounty.entity.HolidayCounty;
 import io.mipangg.holidaykeeper.domain.holidayCounty.repository.HolidayCountyRepository;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,12 +50,28 @@ public class HolidayCountyService {
     }
 
     @Transactional
-    public void deleteHolidayCounties(List<Holiday> holidays) {
+    public void deleteHolidayCounties(List<Long> holidayIds) {
         List<HolidayCounty> targetHolidayCounties =
-                holidayCountyRepository.findByHolidayIn(holidays);
+                holidayCountyRepository.findByHolidayIdIn(holidayIds);
 
         if (targetHolidayCounties != null && !targetHolidayCounties.isEmpty()) {
             holidayCountyRepository.deleteAll(targetHolidayCounties);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, List<String>> getHolidayCountyMapByHolidayIds(List<Long> holidayIds) {
+        Map<Long, List<String>> holidayCountyMap = new HashMap<>();
+
+        List<HolidayCounty> holidayCounties = holidayCountyRepository.findByHolidayIdIn(holidayIds);
+        holidayCounties.forEach(holidayCounty -> {
+            Long holidayId = holidayCounty.getHoliday().getId();
+            String county = holidayCounty.getCounty().getCounty();
+            holidayCountyMap
+                    .computeIfAbsent(holidayId, k -> new ArrayList<>())
+                    .add(county);
+        });
+
+        return holidayCountyMap;
     }
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holidayType/repository/HolidayTypeRepository.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holidayType/repository/HolidayTypeRepository.java
@@ -1,6 +1,5 @@
 package io.mipangg.holidaykeeper.domain.holidayType.repository;
 
-import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
 import io.mipangg.holidaykeeper.domain.holidayType.entity.HolidayType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface HolidayTypeRepository extends JpaRepository<HolidayType, Long> {
 
-    @Query("select ht from HolidayType ht where ht.holiday in :holidays")
-    List<HolidayType> findByHolidayIn(@Param("holidays") List<Holiday> holidays);
+    @Query("select ht from HolidayType ht "
+            + "join fetch ht.type where ht.holiday.id in :holidayIds")
+    List<HolidayType> findByHolidayIdIn(@Param("holidayIds") List<Long> holidayIds);
 }

--- a/src/main/java/io/mipangg/holidaykeeper/domain/holidayType/service/HolidayTypeService.java
+++ b/src/main/java/io/mipangg/holidaykeeper/domain/holidayType/service/HolidayTypeService.java
@@ -7,6 +7,7 @@ import io.mipangg.holidaykeeper.domain.holidayType.repository.HolidayTypeReposit
 import io.mipangg.holidaykeeper.domain.type.entity.Type;
 import io.mipangg.holidaykeeper.domain.type.service.TypeService;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -46,11 +47,27 @@ public class HolidayTypeService {
     }
 
     @Transactional
-    public void deleteHolidayTypes(List<Holiday> holidays) {
-        List<HolidayType> targetHolidayTypes = holidayTypeRepository.findByHolidayIn(holidays);
+    public void deleteHolidayTypes(List<Long> holidayIds) {
+        List<HolidayType> targetHolidayTypes = holidayTypeRepository.findByHolidayIdIn(holidayIds);
 
         if (!targetHolidayTypes.isEmpty()) {
             holidayTypeRepository.deleteAll(targetHolidayTypes);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, List<String>> getHolidayTypeMapByHolidayIds(List<Long> holidayIds) {
+        Map<Long, List<String>> holidayTypeMap = new HashMap<>();
+
+        List<HolidayType> holidayTypes = holidayTypeRepository.findByHolidayIdIn(holidayIds);
+        holidayTypes.forEach(holidayType -> {
+            Long holidayId = holidayType.getHoliday().getId();
+            String type = holidayType.getType().getType();
+            holidayTypeMap
+                    .computeIfAbsent(holidayId, k -> new ArrayList<>())
+                    .add(type);
+        });
+
+        return holidayTypeMap;
     }
 }

--- a/src/main/java/io/mipangg/holidaykeeper/global/config/QuerydslConfig.java
+++ b/src/main/java/io/mipangg/holidaykeeper/global/config/QuerydslConfig.java
@@ -1,4 +1,20 @@
 package io.mipangg.holidaykeeper.global.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+
 }

--- a/src/main/java/io/mipangg/holidaykeeper/global/config/QuerydslConfig.java
+++ b/src/main/java/io/mipangg/holidaykeeper/global/config/QuerydslConfig.java
@@ -1,0 +1,4 @@
+package io.mipangg.holidaykeeper.global.config;
+
+public class QuerydslConfig {
+}

--- a/src/test/java/io/mipangg/holidaykeeper/domain/country/service/CountryServiceTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/country/service/CountryServiceTests.java
@@ -1,8 +1,8 @@
 package io.mipangg.holidaykeeper.domain.country.service;
 
-import static io.mipangg.holidaykeeper.util.TestUtil.getCountryBrazil;
-import static io.mipangg.holidaykeeper.util.TestUtil.getCountryCanada;
-import static io.mipangg.holidaykeeper.util.TestUtil.getCountryKorea;
+import static io.mipangg.holidaykeeper.util.TestUtil.genCountryBrazil;
+import static io.mipangg.holidaykeeper.util.TestUtil.genCountryCanada;
+import static io.mipangg.holidaykeeper.util.TestUtil.genCountryKorea;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyCollection;
@@ -51,9 +51,9 @@ class CountryServiceTests {
 
         // List<ExternalCountryResponse> -> Map<String, Country>로 변환
         Map<String, Country> expected = Map.of(
-                "BR", getCountryBrazil(),
-                "CA", getCountryCanada(),
-                "KR", getCountryKorea()
+                "BR", genCountryBrazil(),
+                "CA", genCountryCanada(),
+                "KR", genCountryKorea()
         );
 
         // countryRepository.saveAll(List<Country>)로 한번에 저장

--- a/src/test/java/io/mipangg/holidaykeeper/domain/county/service/CountyServiceTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/county/service/CountyServiceTests.java
@@ -1,7 +1,7 @@
 package io.mipangg.holidaykeeper.domain.county.service;
 
 
-import static io.mipangg.holidaykeeper.util.TestUtil.getCountryCanada;
+import static io.mipangg.holidaykeeper.util.TestUtil.genCountryCanada;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -35,7 +35,7 @@ class CountyServiceTests {
     @DisplayName("county가 이미 존재하면 반환하고 없으면 저장 후 반환하는 기능 테스트")
     void getOrCreateCountiesTest() {
 
-        Country canada = getCountryCanada();
+        Country canada = genCountryCanada();
         Set<CountyElemDto> countyDtos = Set.of(
                 new CountyElemDto(
                         canada,

--- a/src/test/java/io/mipangg/holidaykeeper/domain/holiday/controller/HolidayControllerTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/holiday/controller/HolidayControllerTests.java
@@ -1,18 +1,31 @@
 package io.mipangg.holidaykeeper.domain.holiday.controller;
 
+import static io.mipangg.holidaykeeper.util.TestUtil.genHolidayListReadResponses;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import io.mipangg.holidaykeeper.domain.common.PageResponse;
 import io.mipangg.holidaykeeper.domain.country.service.CountryService;
+import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayListReadResponse;
+import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayReadRequest;
 import io.mipangg.holidaykeeper.domain.holiday.service.HolidayService;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -52,6 +65,40 @@ class HolidayControllerTests {
                 .andDo(print());
 
         verify(holidayService).deleteHolidays(year, countryCode);
+    }
+
+    @Test
+    @DisplayName("공휴일 목록 조회 테스트")
+    void readHolidaysTest() throws Exception {
+
+        int year = 2026;
+        String countryCode = "KR";
+
+        List<HolidayListReadResponse> content = genHolidayListReadResponses();
+        Page<HolidayListReadResponse> page = new PageImpl<>(content, PageRequest.of(0, 20), 2);
+        PageResponse<HolidayListReadResponse> resp = new PageResponse<>(page);
+
+        when(holidayService.searchHolidays(eq(year), eq(countryCode), any(HolidayReadRequest.class))).thenReturn(resp);
+
+        mockMvc.perform(get("/holidays/{year}/{countryCode}", year, countryCode)
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].date").value("2026-01-01"))
+                .andExpect(jsonPath("$.content[0].localName").value("새해"))
+                .andExpect(jsonPath("$.content[0].name").value("New Year's Day"))
+                .andExpect(jsonPath("$.content[0].country").value("South Korea"))
+                .andExpect(jsonPath("$.content[1].date").value("2026-02-16"))
+                .andExpect(jsonPath("$.content[1].localName").value("설날"))
+                .andExpect(jsonPath("$.content[1].name").value("Lunar New Year"))
+                .andExpect(jsonPath("$.content[1].country").value("South Korea"))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(20))
+                .andExpect(jsonPath("$.totalElements").value(2))
+                .andExpect(jsonPath("$.hasNext").value(false))
+                .andDo(print());
+
+
     }
 
 }

--- a/src/test/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayServiceTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayServiceTests.java
@@ -1,7 +1,7 @@
 package io.mipangg.holidaykeeper.domain.holiday.service;
 
-import static io.mipangg.holidaykeeper.util.TestUtil.getCountries;
-import static io.mipangg.holidaykeeper.util.TestUtil.getHolidayKorea;
+import static io.mipangg.holidaykeeper.util.TestUtil.genCountries;
+import static io.mipangg.holidaykeeper.util.TestUtil.genHolidayKorea;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -51,7 +51,7 @@ class HolidayServiceTests {
         int fetchYear = 1;
 
         Map<String, Country> countries = new HashMap<>();
-        getCountries().forEach(c -> {
+        genCountries().forEach(c -> {
             countries.put(c.getCountryCode(), c);
         });
 
@@ -87,7 +87,7 @@ class HolidayServiceTests {
     void saveHolidays409FailTest() {
 
         Map<String, Country> countries = new HashMap<>();
-        getCountries().forEach(c -> {
+        genCountries().forEach(c -> {
             countries.put(c.getCountryCode(), c);
         });
 
@@ -110,7 +110,7 @@ class HolidayServiceTests {
         String countryCode = "KR";
 
         List<Holiday> targetHolidays = List.of(
-                getHolidayKorea()
+                genHolidayKorea()
         );
 
         when(holidayRepository.findByYearAndCountryCode(year, countryCode))

--- a/src/test/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayServiceTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/holiday/service/HolidayServiceTests.java
@@ -2,15 +2,21 @@ package io.mipangg.holidaykeeper.domain.holiday.service;
 
 import static io.mipangg.holidaykeeper.util.TestUtil.genCountries;
 import static io.mipangg.holidaykeeper.util.TestUtil.genHolidayKorea;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.mipangg.holidaykeeper.domain.common.PageResponse;
 import io.mipangg.holidaykeeper.domain.country.entity.Country;
+import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayListReadResponse;
+import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayReadRequest;
 import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
 import io.mipangg.holidaykeeper.domain.holiday.properties.HolidayProperties;
 import io.mipangg.holidaykeeper.domain.holiday.repository.HolidayRepository;
@@ -19,6 +25,7 @@ import io.mipangg.holidaykeeper.domain.holidayType.service.HolidayTypeService;
 import io.mipangg.holidaykeeper.external.dto.ExternalHolidayResponse;
 import io.mipangg.holidaykeeper.external.service.ExternalApiClient;
 import io.mipangg.holidaykeeper.global.exception.CustomLogicException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +35,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 @ExtendWith(MockitoExtension.class)
 class HolidayServiceTests {
@@ -43,6 +53,12 @@ class HolidayServiceTests {
 
     @Mock
     private HolidayProperties holidayProperties;
+
+    @Mock
+    private HolidayCountyService holidayCountyService;
+
+    @Mock
+    private HolidayTypeService holidayTypeService;
 
     @Test
     @DisplayName("holiday 저장 테스트")
@@ -136,6 +152,33 @@ class HolidayServiceTests {
                 }
         ).isInstanceOf(CustomLogicException.class);
 
+    }
+    
+    @Test
+    @DisplayName("특정 연도·국가의 공휴일 목록 조회 테스트")
+    void searchHolidaysTest() {
+    
+        int year = 2026;
+        String countryCode = "KR";
+        HolidayReadRequest req = new HolidayReadRequest(0, 20, null, null, null);
+
+        Holiday holiday = genHolidayKorea();
+
+        Page<Holiday> page = new PageImpl<>(List.of(holiday), PageRequest.of(0, 20), 1);
+
+        when(holidayRepository.searchHoliday(
+                anyInt(), anyString(), any(), any(), any(), any())
+        ).thenReturn(page);
+        when(holidayCountyService.getHolidayCountyMapByHolidayIds(anyList()))
+                .thenReturn(Collections.emptyMap());
+        when(holidayTypeService.getHolidayTypeMapByHolidayIds(anyList()))
+                .thenReturn(Collections.emptyMap());
+
+        PageResponse<HolidayListReadResponse> result =
+                holidayService.searchHolidays(year, countryCode, req);
+
+        assertThat(result.getContent().getFirst().localName()).isEqualTo("새해");
+        assertThat(result.getContent().getFirst().name()).isEqualTo("New Year's Day");
     }
 
 }

--- a/src/test/java/io/mipangg/holidaykeeper/domain/holidayCounty/service/HolidayCountyServiceTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/holidayCounty/service/HolidayCountyServiceTests.java
@@ -1,6 +1,6 @@
 package io.mipangg.holidaykeeper.domain.holidayCounty.service;
 
-import static io.mipangg.holidaykeeper.util.TestUtil.getHolidayCanada;
+import static io.mipangg.holidaykeeper.util.TestUtil.genHolidayCanada;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,7 +36,7 @@ class HolidayCountyServiceTests {
     @Test
     @DisplayName("holidayCounty 저장 기능 테스트")
     void saveHolidayCountiesTest() {
-        Holiday holidayCanada = getHolidayCanada();
+        Holiday holidayCanada = genHolidayCanada();
         Country canada = holidayCanada.getCountry();
         List<HolidayCountiesDto> holidayCountiesDtos = List.of(
                 new HolidayCountiesDto(
@@ -62,7 +62,7 @@ class HolidayCountyServiceTests {
     @Test
     @DisplayName("holidayCounty 삭제 테스트")
     void deleteHolidayCountiesTest() {
-        List<Holiday> holidays = List.of(getHolidayCanada());
+        List<Holiday> holidays = List.of(genHolidayCanada());
         Country canada = holidays.getFirst().getCountry();
         List<HolidayCounty> targetHolidayCounties = List.of(
                 HolidayCounty.builder()

--- a/src/test/java/io/mipangg/holidaykeeper/domain/holidayCounty/service/HolidayCountyServiceTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/holidayCounty/service/HolidayCountyServiceTests.java
@@ -1,11 +1,13 @@
 package io.mipangg.holidaykeeper.domain.holidayCounty.service;
 
+import static io.mipangg.holidaykeeper.util.TestUtil.genCountyAb;
+import static io.mipangg.holidaykeeper.util.TestUtil.genCountyPe;
 import static io.mipangg.holidaykeeper.util.TestUtil.genHolidayCanada;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.mipangg.holidaykeeper.domain.country.entity.Country;
 import io.mipangg.holidaykeeper.domain.county.entity.County;
 import io.mipangg.holidaykeeper.domain.county.service.CountyService;
 import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayCountiesDto;
@@ -14,6 +16,7 @@ import io.mipangg.holidaykeeper.domain.holidayCounty.entity.HolidayCounty;
 import io.mipangg.holidaykeeper.domain.holidayCounty.repository.HolidayCountyRepository;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,7 +40,6 @@ class HolidayCountyServiceTests {
     @DisplayName("holidayCounty 저장 기능 테스트")
     void saveHolidayCountiesTest() {
         Holiday holidayCanada = genHolidayCanada();
-        Country canada = holidayCanada.getCountry();
         List<HolidayCountiesDto> holidayCountiesDtos = List.of(
                 new HolidayCountiesDto(
                         holidayCanada,
@@ -48,8 +50,8 @@ class HolidayCountyServiceTests {
                 )
         );
         Map<String, County> counties = Map.of(
-                "CA-AB", County.builder().county("CA-AB").country(canada).build(),
-                "CA-PE", County.builder().county("CA-PE").country(canada).build()
+                "CA-AB", genCountyAb(),
+                "CA-PE", genCountyPe()
         );
 
         when(countyService.getOrCreateCounties(anySet())).thenReturn(counties);
@@ -63,33 +65,45 @@ class HolidayCountyServiceTests {
     @DisplayName("holidayCounty 삭제 테스트")
     void deleteHolidayCountiesTest() {
         List<Holiday> holidays = List.of(genHolidayCanada());
-        Country canada = holidays.getFirst().getCountry();
+        List<Long> holidayIds = holidays.stream()
+                .map(Holiday::getId)
+                .collect(Collectors.toList());
         List<HolidayCounty> targetHolidayCounties = List.of(
                 HolidayCounty.builder()
-                        .county(
-                                County.builder()
-                                        .county("CA-AB")
-                                        .country(canada)
-                                        .build()
-                        )
+                        .county(genCountyAb())
                         .build(),
                 HolidayCounty.builder()
-                        .county(
-                                County.builder()
-                                        .county("CA-PE")
-                                        .country(canada)
-                                        .build()
-                        )
+                        .county(genCountyPe())
                         .build()
         );
 
-        when(holidayCountyRepository.findByHolidayIn(holidays)).thenReturn(targetHolidayCounties);
+        when(holidayCountyRepository.findByHolidayIdIn(holidayIds)).thenReturn(targetHolidayCounties);
 
-        holidayCountyService.deleteHolidayCounties(holidays);
+        holidayCountyService.deleteHolidayCounties(holidayIds);
 
-        verify(holidayCountyRepository).findByHolidayIn(holidays);
+        verify(holidayCountyRepository).findByHolidayIdIn(holidayIds);
         verify(holidayCountyRepository).deleteAll(targetHolidayCounties);
 
+    }
+
+    @Test
+    @DisplayName("holidayId 목록으로 holidayCounty를 조회하여 map으로 반환하는 기능 테스트")
+    void getHolidayCountyMapByHolidayIdsTest() {
+
+        List<Long> holidayIds = List.of(1L, 2L);
+        List<HolidayCounty> holidayCounties = List.of(
+                HolidayCounty.builder().holiday(genHolidayCanada()).county(genCountyAb()).build(),
+                HolidayCounty.builder().holiday(genHolidayCanada()).county(genCountyPe()).build()
+        );
+
+        when(holidayCountyRepository.findByHolidayIdIn(holidayIds)).thenReturn(holidayCounties);
+
+        Map<Long, List<String>> result = holidayCountyService
+                .getHolidayCountyMapByHolidayIds(holidayIds);
+
+        assertThat(result.get(2L)).hasSize(2);
+        assertThat(result.get(2L).getFirst()).isEqualTo("CA-AB");
+        assertThat(result.get(2L).getLast()).isEqualTo("CA-PE");
     }
 
 }

--- a/src/test/java/io/mipangg/holidaykeeper/domain/holidayType/service/HolidayTypeServiceTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/holidayType/service/HolidayTypeServiceTests.java
@@ -1,6 +1,11 @@
 package io.mipangg.holidaykeeper.domain.holidayType.service;
 
 import static io.mipangg.holidaykeeper.util.TestUtil.genHolidayBrazil;
+import static io.mipangg.holidaykeeper.util.TestUtil.genHolidayCanada;
+import static io.mipangg.holidaykeeper.util.TestUtil.genHolidayKorea;
+import static io.mipangg.holidaykeeper.util.TestUtil.genTypeBank;
+import static io.mipangg.holidaykeeper.util.TestUtil.genTypePublic;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.verify;
@@ -14,6 +19,7 @@ import io.mipangg.holidaykeeper.domain.type.entity.Type;
 import io.mipangg.holidaykeeper.domain.type.service.TypeService;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,6 +67,9 @@ class HolidayTypeServiceTests {
     void deleteHolidayTypesTest() {
 
         List<Holiday> holidays = List.of(genHolidayBrazil());
+        List<Long> holidayIds = holidays.stream()
+                .map(Holiday::getId)
+                .collect(Collectors.toList());
         List<HolidayType> targetHolidayTypes = List.of(
                 HolidayType.builder()
                         .type(Type.builder().type("Public").build())
@@ -72,13 +81,38 @@ class HolidayTypeServiceTests {
                         .build()
         );
 
-        when(holidayTypeRepository.findByHolidayIn(holidays)).thenReturn(targetHolidayTypes);
+        when(holidayTypeRepository.findByHolidayIdIn(holidayIds)).thenReturn(targetHolidayTypes);
 
-        holidayTypeService.deleteHolidayTypes(holidays);
+        holidayTypeService.deleteHolidayTypes(holidayIds);
 
-        verify(holidayTypeRepository).findByHolidayIn(anyList());
+        verify(holidayTypeRepository).findByHolidayIdIn(anyList());
         verify(holidayTypeRepository).deleteAll(targetHolidayTypes);
 
+    }
+
+    @Test
+    @DisplayName("holidayId 리스트로 holidayType을 조회하여 Map으로 반환하는 기능 테스트")
+    void getHolidayTypeMapByHolidayIdsTest() {
+
+        List<Long> holidayIds = List.of(1L, 2L, 3L);
+        List<HolidayType> holidayTypes = List.of(
+                HolidayType.builder().holiday(genHolidayBrazil()).type(genTypePublic()).build(),
+                HolidayType.builder().holiday(genHolidayBrazil()).type(genTypeBank()).build(),
+                HolidayType.builder().holiday(genHolidayCanada()).type(genTypePublic()).build(),
+                HolidayType.builder().holiday(genHolidayKorea()).type(genTypePublic()).build()
+        );
+
+        when(holidayTypeRepository.findByHolidayIdIn(holidayIds)).thenReturn(holidayTypes);
+
+        Map<Long, List<String>> result = holidayTypeService.getHolidayTypeMapByHolidayIds(holidayIds);
+
+        assertThat(result.get(1L)).hasSize(2);
+        assertThat(result.get(2L)).hasSize(1);
+        assertThat(result.get(3L)).hasSize(1);
+        assertThat(result.get(1L).getFirst()).isEqualTo("Public");
+        assertThat(result.get(1L).getLast()).isEqualTo("Bank");
+        assertThat(result.get(2L).getFirst()).isEqualTo("Public");
+        assertThat(result.get(3L).getFirst()).isEqualTo("Public");
     }
 
 }

--- a/src/test/java/io/mipangg/holidaykeeper/domain/holidayType/service/HolidayTypeServiceTests.java
+++ b/src/test/java/io/mipangg/holidaykeeper/domain/holidayType/service/HolidayTypeServiceTests.java
@@ -1,6 +1,6 @@
 package io.mipangg.holidaykeeper.domain.holidayType.service;
 
-import static io.mipangg.holidaykeeper.util.TestUtil.getHolidayBrazil;
+import static io.mipangg.holidaykeeper.util.TestUtil.genHolidayBrazil;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.verify;
@@ -14,7 +14,6 @@ import io.mipangg.holidaykeeper.domain.type.entity.Type;
 import io.mipangg.holidaykeeper.domain.type.service.TypeService;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,7 +39,7 @@ class HolidayTypeServiceTests {
 
         List<HolidayTypesDto> holidayTypesDtos = List.of(
                 new HolidayTypesDto(
-                        getHolidayBrazil(),
+                        genHolidayBrazil(),
                         List.of("Public", "Bank")
                 )
         );
@@ -61,7 +60,7 @@ class HolidayTypeServiceTests {
     @DisplayName("holidayType 삭제 테스트")
     void deleteHolidayTypesTest() {
 
-        List<Holiday> holidays = List.of(getHolidayBrazil());
+        List<Holiday> holidays = List.of(genHolidayBrazil());
         List<HolidayType> targetHolidayTypes = List.of(
                 HolidayType.builder()
                         .type(Type.builder().type("Public").build())

--- a/src/test/java/io/mipangg/holidaykeeper/util/TestUtil.java
+++ b/src/test/java/io/mipangg/holidaykeeper/util/TestUtil.java
@@ -1,71 +1,98 @@
 package io.mipangg.holidaykeeper.util;
 
+import io.mipangg.holidaykeeper.domain.common.PageResponse;
 import io.mipangg.holidaykeeper.domain.country.entity.Country;
+import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayListReadResponse;
 import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 public class TestUtil {
 
-    public static Country getCountryBrazil() {
+    public static Country genCountryBrazil() {
         return Country.builder()
                 .name("Brazil")
                 .countryCode("BR")
                 .build();
     }
 
-    public static Country getCountryCanada() {
+    public static Country genCountryCanada() {
         return Country.builder()
                 .name("Canada")
                 .countryCode("CA")
                 .build();
     }
 
-    public static Country getCountryKorea() {
+    public static Country genCountryKorea() {
         return Country.builder()
                 .name("South Korea")
                 .countryCode("KR")
                 .build();
     }
 
-    public static List<Country> getCountries() {
-        return List.of(getCountryBrazil(), getCountryCanada(), getCountryKorea());
+    public static List<Country> genCountries() {
+        return List.of(genCountryBrazil(), genCountryCanada(), genCountryKorea());
     }
 
-    public static Holiday getHolidayBrazil() {
+    public static Holiday genHolidayBrazil() {
         return Holiday.builder()
                 .date(LocalDate.of(2026, 2, 16))
                 .localName("Carnaval")
                 .name("Carnival")
-                .country(getCountryBrazil())
+                .country(genCountryBrazil())
                 .fixed(false)
                 .global(true)
                 .launchYear(null)
                 .build();
     }
 
-    public static Holiday getHolidayCanada() {
+    public static Holiday genHolidayCanada() {
         return Holiday.builder()
                 .date(LocalDate.of(2026, 4, 6))
                 .localName("Easter Monday")
                 .name("Easter Monday")
-                .country(getCountryCanada())
+                .country(genCountryCanada())
                 .fixed(false)
                 .global(false)
                 .launchYear(null)
                 .build();
     }
 
-    public static Holiday getHolidayKorea() {
+    public static Holiday genHolidayKorea() {
         return Holiday.builder()
                 .date(LocalDate.of(2026, 1, 1))
                 .localName("새해")
                 .name("New Year's Day")
-                .country(getCountryKorea())
+                .country(genCountryKorea())
                 .fixed(false)
                 .global(true)
                 .launchYear(null)
                 .build();
     }
+
+    public static List<HolidayListReadResponse> genHolidayListReadResponses() {
+        return List.of(
+                new HolidayListReadResponse(
+                        1L,
+                        LocalDate.of(2026, 1, 1),
+                        "새해",
+                        "New Year's Day",
+                        "South Korea",
+                        null,
+                        List.of("Public")
+                ),
+                new HolidayListReadResponse(
+                        2L,
+                        LocalDate.of(2026, 2, 16),
+                        "설날",
+                        "Lunar New Year",
+                        "South Korea",
+                        null,
+                        List.of("Public")
+                )
+        );
+    }
+
 
 }

--- a/src/test/java/io/mipangg/holidaykeeper/util/TestUtil.java
+++ b/src/test/java/io/mipangg/holidaykeeper/util/TestUtil.java
@@ -1,12 +1,12 @@
 package io.mipangg.holidaykeeper.util;
 
-import io.mipangg.holidaykeeper.domain.common.PageResponse;
 import io.mipangg.holidaykeeper.domain.country.entity.Country;
+import io.mipangg.holidaykeeper.domain.county.entity.County;
 import io.mipangg.holidaykeeper.domain.holiday.dto.HolidayListReadResponse;
 import io.mipangg.holidaykeeper.domain.holiday.entity.Holiday;
+import io.mipangg.holidaykeeper.domain.type.entity.Type;
 import java.time.LocalDate;
 import java.util.List;
-import org.springframework.data.domain.Page;
 
 public class TestUtil {
 
@@ -37,6 +37,7 @@ public class TestUtil {
 
     public static Holiday genHolidayBrazil() {
         return Holiday.builder()
+                .id(1L)
                 .date(LocalDate.of(2026, 2, 16))
                 .localName("Carnaval")
                 .name("Carnival")
@@ -49,6 +50,7 @@ public class TestUtil {
 
     public static Holiday genHolidayCanada() {
         return Holiday.builder()
+                .id(2L)
                 .date(LocalDate.of(2026, 4, 6))
                 .localName("Easter Monday")
                 .name("Easter Monday")
@@ -61,6 +63,7 @@ public class TestUtil {
 
     public static Holiday genHolidayKorea() {
         return Holiday.builder()
+                .id(3L)
                 .date(LocalDate.of(2026, 1, 1))
                 .localName("새해")
                 .name("New Year's Day")
@@ -68,6 +71,32 @@ public class TestUtil {
                 .fixed(false)
                 .global(true)
                 .launchYear(null)
+                .build();
+    }
+
+    public static Type genTypePublic() {
+        return Type.builder()
+                .type("Public")
+                .build();
+    }
+
+    public static Type genTypeBank() {
+        return Type.builder()
+                .type("Bank")
+                .build();
+    }
+
+    public static County genCountyAb() {
+        return County.builder()
+                .county("CA-AB")
+                .country(genCountryCanada())
+                .build();
+    }
+
+    public static County genCountyPe() {
+        return County.builder()
+                .county("CA-PE")
+                .country(genCountryCanada())
                 .build();
     }
 
@@ -93,6 +122,5 @@ public class TestUtil {
                 )
         );
     }
-
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #9 

## 📝작업 내용
- 특정 연도, 국가의 공휴일 목록 조회
- from ~ to 기간 필터링
- 공휴일 타입 필터링
- 페이징 응답

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함
